### PR TITLE
Allow nightly release custom versions for ZURG_VERSION

### DIFF
--- a/zurg/download.py
+++ b/zurg/download.py
@@ -155,7 +155,10 @@ def version_check():
             repo_name = 'zurg-testing'          
         
         if ZURGVERSION:
-            release_version = ZURGVERSION if ZURGVERSION.startswith('v') else 'v' + ZURGVERSION
+            if "nightly" in ZURGVERSION.lower():
+                release_version = ZURGVERSION
+            else:
+                release_version = ZURGVERSION if ZURGVERSION.startswith('v') else 'v' + ZURGVERSION
             logger.info("Using release version from environment variable: %s", release_version)
         else:      
             release_version, error = get_latest_release(repo_owner, repo_name)


### PR DESCRIPTION
Don't prepend 'v' for zurg custom version nightly releases